### PR TITLE
replacing absolute paths with relative ones

### DIFF
--- a/packages/cra-example/config/webpack.config.dev.js
+++ b/packages/cra-example/config/webpack.config.dev.js
@@ -187,7 +187,7 @@ module.exports = {
         ],
         include: [
           paths.appSrc,
-          '/src/packages/cra-example/src',
+          path.resolve(process.env.BUILD_WORKSPACE_DIRECTORY, 'cra-example/src'),
         ],
       },
       {
@@ -212,7 +212,7 @@ module.exports = {
             test: /\.(js|mjs|jsx)$/,
             include: [
               paths.appSrc,
-              '/src/packages/cra-example/src',
+              path.resolve(process.env.BUILD_WORKSPACE_DIRECTORY, 'cra-example/src'),
             ],
             loader: require.resolve('babel-loader'),
             options: {

--- a/packages/cra-example/config/webpack.config.prod.js
+++ b/packages/cra-example/config/webpack.config.prod.js
@@ -110,7 +110,7 @@ module.exports = {
   entry: [paths.appIndexJs],
   output: {
     // The build folder.
-    path: '/src/packages/cra-example/build/',
+    path: path.resolve(process.env.BUILD_WORKSPACE_DIRECTORY, 'cra-example/build/'),
     // Generated JS file names (with nested folders).
     // There will be one main bundle, and one file per asynchronous chunk.
     // We don't currently advertise code splitting but Webpack supports it.
@@ -261,7 +261,7 @@ module.exports = {
         ],
         include: [
           paths.appSrc,
-          '/src/packages/cra-example/src',
+          path.resolve(process.env.BUILD_WORKSPACE_DIRECTORY, 'cra-example/src'),
         ],
       },
       {
@@ -285,7 +285,7 @@ module.exports = {
             test: /\.(js|mjs|jsx)$/,
             include: [
               paths.appSrc,
-              '/src/packages/cra-example/src',
+              path.resolve(process.env.BUILD_WORKSPACE_DIRECTORY, 'cra-example/src'),
             ],
             loader: require.resolve('babel-loader'),
             options: {


### PR DESCRIPTION
Now we can run locally without a docker. https://github.com/bazelbuild/rules_nodejs/issues/373#issuecomment-432274291
```
$ cd packages
$ bazel run //cra-example
```